### PR TITLE
Prepend and overflow scaling factors

### DIFF
--- a/lastfmng/defaults.ini
+++ b/lastfmng/defaults.ini
@@ -21,8 +21,14 @@ enabled = True
 limit = 4
 ; name of another category, unused tags in this category will be used in the given one.
 overflow =
+; scale the score when overflowing.  If Rock(56000) is overflowed, it will be scaled by this value
+; before it is used.  For example you may want to overflow from grouping --> genre but cut this value
+; in half.  In this case use 0.5.
+overflow_scale = 1.0
 ; add all tags from the other category to this one
 prepend =
+; scale value when prepending.  Similar to overflow above.
+prepend_scale = 1.0
 ; used to join tags if >1 are to be used (None to use multtag)
 separator =
 ; alphabetically sort tags before joining to string

--- a/lastfmng/helpers/tags.py
+++ b/lastfmng/helpers/tags.py
@@ -30,6 +30,10 @@ def join_tags(tuples, limit=None, separator=", ", sort=True, apply_titlecase=Tru
     tags are joined together using ", " (override using separator)
     if separator is None, tags are not joined, but a list is returned
     """
+
+    # first resort the list by score after our appending/prepending stuff
+    tuples = apply_tag_weight((tuples, 1.0))
+
     # first limit to only the top ones...
     if limit:
         tuples = tuples[:limit]

--- a/lastfmng/helpers/tags.py
+++ b/lastfmng/helpers/tags.py
@@ -30,10 +30,6 @@ def join_tags(tuples, limit=None, separator=", ", sort=True, apply_titlecase=Tru
     tags are joined together using ", " (override using separator)
     if separator is None, tags are not joined, but a list is returned
     """
-
-    # first resort the list by score after our appending/prepending stuff
-    tuples = apply_tag_weight((tuples, 1.0))
-
     # first limit to only the top ones...
     if limit:
         tuples = tuples[:limit]

--- a/lastfmng/plugin.py
+++ b/lastfmng/plugin.py
@@ -117,18 +117,15 @@ class TaggerBase(DebugMixin, QtCore.QObject):
                     category, str(category.prepend_scale), category.prepend,
                     ', '.join(['{} ({})'.format(t, s*category.prepend_scale) for t, s in result[category.prepend]]) or 'None'
                 )
-                log.info([(t, s*category.prepend_scale) for t, s in result[category.prepend]])
-                log.info(result[category.name])
-                log.info('concat')
+                #actually do the prepend with scaling
                 result[category.name] = [(t, s*category.prepend_scale) for t, s in result[category.prepend]] + result[category.name]
-                log.info(result[category.name])
 
-            #resort by score before providing to join_tags
+            #re-sort by score before providing to join_tags
             #using apply_tag_weight with scaling of 1.0 as a sorting function
             result[category.name] = apply_tag_weight((result[category.name], 1.0))
 
             #show final tags
-            log.info('Tags before selection:')
+            log.info('Final tags before making choice:')
             log.info(result[category.name])
 
             # category is done, assign tags to metadata

--- a/lastfmng/plugin.py
+++ b/lastfmng/plugin.py
@@ -119,8 +119,10 @@ class TaggerBase(DebugMixin, QtCore.QObject):
                 )
                 result[category.name] = [(t, s*category.prepend_scale) for t, s in result[category.prepend]] + \
                                         result[category.name]
-                log.info("here in prepend")
-                log.info(result[category.name])
+
+            #resort by score before providing to join_tags
+            #using apply_tag_weight with scaling of 1.0 as a sorting function
+            result[category.name] = apply_tag_weight((result[category.name], 1.0))
 
             # category is done, assign tags to metadata
             metatag = category.get_metatag(scope)

--- a/lastfmng/plugin.py
+++ b/lastfmng/plugin.py
@@ -117,12 +117,19 @@ class TaggerBase(DebugMixin, QtCore.QObject):
                     category, str(category.prepend_scale), category.prepend,
                     ', '.join(['{} ({})'.format(t, s*category.prepend_scale) for t, s in result[category.prepend]]) or 'None'
                 )
-                result[category.name] = [(t, s*category.prepend_scale) for t, s in result[category.prepend]] + \
-                                        result[category.name]
+                log.info([(t, s*category.prepend_scale) for t, s in result[category.prepend]])
+                log.info(result[category.name])
+                log.info('concat')
+                result[category.name] = [(t, s*category.prepend_scale) for t, s in result[category.prepend]] + result[category.name]
+                log.info(result[category.name])
 
             #resort by score before providing to join_tags
             #using apply_tag_weight with scaling of 1.0 as a sorting function
             result[category.name] = apply_tag_weight((result[category.name], 1.0))
+
+            #show final tags
+            log.info('Tags before selection:')
+            log.info(result[category.name])
 
             # category is done, assign tags to metadata
             metatag = category.get_metatag(scope)

--- a/lastfmng/plugin.py
+++ b/lastfmng/plugin.py
@@ -101,25 +101,26 @@ class TaggerBase(DebugMixin, QtCore.QObject):
                 # the overflowed toptags are not considered in the threshold
                 # calculation of that category, they are put directly into
                 # the result list.
-                log.info("%s: overflow to %s: %s",
-                    category, category.overflow,
-                    ', '.join(['{} ({})'.format(t, s) for t, s in overflow])
+                log.info("%s: overflow (and scale by %s) to %s: %s",
+                    category, str(category.overflow_scale), category.overflow,
+                    ', '.join(['{} ({})'.format(t, s*category.overflow_scale) for t, s in overflow])
                         or 'None'
                 )
                 if overflow:
-                    result[category.overflow] = overflow
+                    result[category.overflow] = [(t, s*category.overflow_scale) for t, s in overflow]
 
             # if a prepend-category is configured copy the tags from that
             # category in front of this one
             #TODO this works only "downstream" eg from grouping to genre, not the other way round
             if category.prepend:
-                log.info('%s: prepending from %s: %s',
-                    category, category.prepend,
-                    ', '.join(['{} ({})'.format(t, s) for t, s in overflow])
-                        or 'None'
+                log.info('%s: prepending (and scale by %s) from %s: %s',
+                    category, str(category.prepend_scale), category.prepend,
+                    ', '.join(['{} ({})'.format(t, s*category.prepend_scale) for t, s in result[category.prepend]]) or 'None'
                 )
-                result[category.name] = result[category.prepend] + \
+                result[category.name] = [(t, s*category.prepend_scale) for t, s in result[category.prepend]] + \
                                         result[category.name]
+                log.info("here in prepend")
+                log.info(result[category.name])
 
             # category is done, assign tags to metadata
             metatag = category.get_metatag(scope)

--- a/lastfmng/plugin.py
+++ b/lastfmng/plugin.py
@@ -126,7 +126,8 @@ class TaggerBase(DebugMixin, QtCore.QObject):
 
             #show final tags
             log.info('Final tags before making choice:')
-            log.info(result[category.name])
+            log.info('%s', ','.join(['{} ({})'.format(t, s) for t, s in result[category.name]]) or 'None')
+            #log.info(result[category.name])
 
             # category is done, assign tags to metadata
             metatag = category.get_metatag(scope)

--- a/lastfmng/settings.py
+++ b/lastfmng/settings.py
@@ -115,8 +115,16 @@ class Category(object):
         return self.category_config('prepend')
 
     @property
+    def prepend_scale(self):
+        return self.category_config('prepend_scale', 'float', 1.0)
+
+    @property
     def overflow(self):
         return self.category_config('overflow')
+
+    @property
+    def overflow_scale(self):
+        return self.category_config('overflow_scale', 'float', 1.0)
 
     @property
     def sort(self):


### PR DESCRIPTION
So here's my issue.  I love the idea of multiple genres but plain and simple, a lot of the OEM car head units don't support them; they typically will support only one genre.  So MusicBrainz Picard doesn't support tagging with genre, and this script does, so I can still get some use from it.

I need exactly ONE genre to be selected and I want it to be a good one.  My problem is that if I configure this script to use 1 grouping and 1 genre, the item from grouping would get consumed; then I would get the 'sub genre' which in some instances is just not appropriate.

However the sub genres that come from last.fm are still useful and more detailed than what is chosen for the grouping.  So this patch does the following:

It will allow the user to apply a scaling factor on both the OVERFLOWED values from a category AND the PREPENDED values from a category.  An example of this in practice:

```
I: 19:57:08 Last.fm.ng - >>> process track tags
I: 19:57:08 Last.fm.ng - grouping: 10 tag(s) before threshold filter:
I: 19:57:08 Last.fm.ng - grouping: classic rock (1000), rock (450), rock & roll (212), pop (140), hard rock (82), ...
I: 19:57:08 Last.fm.ng - grouping: score threshold: 500.0 (50%)
I: 19:57:08 Last.fm.ng - grouping: 1 tag(s) filtered:
I: 19:57:08 Last.fm.ng - grouping: classic rock (1000)
I: 19:57:08 Last.fm.ng - Final tags before making choice:
I: 19:57:08 Last.fm.ng - classic rock (1000.0)
I: 19:57:08 Last.fm.ng - grouping: metatag: grouping
I: 19:57:08 Last.fm.ng - grouping = Classic Rock
I: 19:57:08 Last.fm.ng - genre: 8 tag(s) before threshold filter:
I: 19:57:08 Last.fm.ng - genre: hard rock (82), honky tonk (72), soft rock (52), blues rock (6), southern rock (6), ...
I: 19:57:08 Last.fm.ng - genre: score threshold: 32.8 (40%)
I: 19:57:08 Last.fm.ng - genre: 3 tag(s) filtered:
I: 19:57:08 Last.fm.ng - genre: hard rock (82), honky tonk (72), soft rock (52)
I: 19:57:08 Last.fm.ng - genre: prepending (and scale by 0.17) from grouping: classic rock (170.0)
I: 19:57:08 Last.fm.ng - Final tags before making choice:
I: 19:57:08 Last.fm.ng - classic rock (170.0),hard rock (82.0)
I: 19:57:08 Last.fm.ng - genre: metatag: genre
I: 19:57:08 Last.fm.ng - genre = Classic Rock
```

Note that classic rock was chosen for the grouping with a score of 1000.  Now, if that value were consumed, the top choice from the 'sub' genres would be hard rock.  No way would I classify ANYTHING from Bob Seger as hard rock!  So in this case I want to carry over the classic rock tag to the sub genres from last.fm, but I don't want it to ALWAYS win.  I want instead to put it in the lineup like the other tags.  

So here I multiply both the overflow AND the prepended values from grouping by 0.17 before I insert them into the genre list for consideration.  And you can see here that classic rock won the battle instead of hard rock.  

Also, there was a bug on line 118 of plugin.py that is fixed here:
`', '.join(['{} ({})'.format(t, s) for t, s in overflow]) or 'None'`
should read:
`', '.join(['{} ({})'.format(t, s) for t, s in result[category.prepend]]) or 'None'`

My config.ini reads like so:

```
[global]
lastfm_key = xxxxxxxxxxxxxxxxxxxxxxxxxxxxxx

[category-defaults]
; used to join tags if >1 are to be used (None to use multtag)
separator = ", "

[category-grouping]
# grouping is used as major/high level category
limit = 1
enabled = True
threshold = 0.5
overflow = genre
overflow_scale = 0.17
metatag_album = albumgenre
metatag_track = grouping 

[category-genre]
limit = 1
threshold = 0.4
prepend = grouping
prepend_scale = 0.17
metatag_album = albummood
metatag_track = genre
```

And I'm getting pretty good results from this.  
